### PR TITLE
[skip ci] Remove Local Development Setup section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Made by the team at [BigBinary](https://bigbinary.com), this is a base project
 to quickly spin up a Rails application built with opinions of BigBinary style of
 working.
 
-## Local Development Setup
 
 First clone this repo.
 


### PR DESCRIPTION
Removed the Local Development Setup section from README.